### PR TITLE
use jr_swizzleMethod:withMethod:error: instead of the shortcut

### DIFF
--- a/Autolayout/PWAutoLayout/NSLayoutConstraint-PWExtensions.m
+++ b/Autolayout/PWAutoLayout/NSLayoutConstraint-PWExtensions.m
@@ -56,12 +56,16 @@ static NSString* const PWOriginalConstantKey = @"net.projectwizards.net.PWOrigin
             // Remember constant for later unhiding of constraint
             self.PWOriginalConstant = @(self.constant);
             self.constant = 0.0;
+
+            self.priority--;
         }
         else
         {
             NSAssert(self.PWOriginalConstant, nil);
             self.constant = self.PWOriginalConstant.doubleValue;
             self.PWOriginalConstant = nil;
+
+            self.priority++;
         }
     }
 }

--- a/Autolayout/PWAutoLayout/NSView-PWExtensions.m
+++ b/Autolayout/PWAutoLayout/NSView-PWExtensions.m
@@ -20,10 +20,10 @@
 + (void)load
 {
     [self jr_swizzleMethod:@selector(setHidden:)
-                withMethod:@selector(PWSwizzled_setHidden:)];
+                withMethod:@selector(PWSwizzled_setHidden:) error:nil];
 
     [self jr_swizzleMethod:@selector(intrinsicContentSize)
-                withMethod:@selector(PWSwizzled_intrinsicContentSize)];
+                withMethod:@selector(PWSwizzled_intrinsicContentSize) error:nil];
 }
 
 #pragma mark - Hiding Master


### PR DESCRIPTION
The shortcut is not in the official JRSwizzle-repository. Use error=nil instead.
